### PR TITLE
Update train.py

### DIFF
--- a/a3c/train.py
+++ b/a3c/train.py
@@ -152,6 +152,7 @@ def learn_proc(mem_queue, weight_dict):
     checkpoint = args.checkpoint
     steps = args.steps
     # -----
+    env = gym.make(args.game)
     agent = LearningAgent(env.action_space, batch_size=args.batch_size, swap_freq=args.swap_freq)
     # -----
     if checkpoint > 0:

--- a/a3c/train.py
+++ b/a3c/train.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from __future__ import division
 from scipy.misc import imresize
 from skimage.color import rgb2gray
 from multiprocessing import *
@@ -151,7 +153,11 @@ def learn_proc(mem_queue, weight_dict):
     steps = args.steps
     # -----
     env = gym.make(args.game)
-    agent = LearningAgent(env.action_space, batch_size=args.batch_size, swap_freq=args.swap_freq)
+    #['NOOP', 'FIRE', 'RIGHT', 'LEFT', 'RIGHTFIRE', 'LEFTFIRE'] - default
+    #['NOOP', 'FIRE', 'RIGHT', 'LEFT'] - our workaround
+    if args.game == 'Breakout-v0' or args.game == 'SpaceInvaders-v0':
+        action_space = Discrete(4)
+    agent = LearningAgent(action_space, batch_size=args.batch_size, swap_freq=args.swap_freq)
     # -----
     if checkpoint > 0:
         print(' %5d> Loading weights from file' % (pid,))
@@ -264,8 +270,13 @@ def generate_experience_proc(mem_queue, weight_dict, no):
     batch_size = args.batch_size
     # -----
     env = gym.make(args.game)
-    agent = ActingAgent(env.action_space, n_step=args.n_step)
-
+    #['NOOP', 'FIRE', 'RIGHT', 'LEFT', 'RIGHTFIRE', 'LEFTFIRE'] - default
+    #['NOOP', 'FIRE', 'RIGHT', 'LEFT'] - our workaround
+    #this work around does not mess with the internals of ALE and will work with any compilation of ALE
+    if args.game == 'Breakout-v0' or args.game == 'SpaceInvaders-v0':
+        action_space = Discrete(4)
+    agent = LearningAgent(action_space, batch_size=args.batch_size, swap_freq=args.swap_freq)
+    # -----
     if frames > 0:
         print(' %5d> Loaded weights from file' % (pid,))
         agent.load_net.load_weights('model-%s-%d.h5' % (args.game, frames))

--- a/a3c/train.py
+++ b/a3c/train.py
@@ -152,12 +152,7 @@ def learn_proc(mem_queue, weight_dict):
     checkpoint = args.checkpoint
     steps = args.steps
     # -----
-    env = gym.make(args.game)
-    #['NOOP', 'FIRE', 'RIGHT', 'LEFT', 'RIGHTFIRE', 'LEFTFIRE'] - default
-    #['NOOP', 'FIRE', 'RIGHT', 'LEFT'] - our workaround
-    if args.game == 'Breakout-v0' or args.game == 'SpaceInvaders-v0':
-        action_space = Discrete(4)
-    agent = LearningAgent(action_space, batch_size=args.batch_size, swap_freq=args.swap_freq)
+    agent = LearningAgent(env.action_space, batch_size=args.batch_size, swap_freq=args.swap_freq)
     # -----
     if checkpoint > 0:
         print(' %5d> Loading weights from file' % (pid,))
@@ -270,12 +265,7 @@ def generate_experience_proc(mem_queue, weight_dict, no):
     batch_size = args.batch_size
     # -----
     env = gym.make(args.game)
-    #['NOOP', 'FIRE', 'RIGHT', 'LEFT', 'RIGHTFIRE', 'LEFTFIRE'] - default
-    #['NOOP', 'FIRE', 'RIGHT', 'LEFT'] - our workaround
-    #this work around does not mess with the internals of ALE and will work with any compilation of ALE
-    if args.game == 'Breakout-v0' or args.game == 'SpaceInvaders-v0':
-        action_space = Discrete(4)
-    agent = LearningAgent(action_space, batch_size=args.batch_size, swap_freq=args.swap_freq)
+    agent = ActingAgent(env.action_space, n_step=args.n_step)
     # -----
     if frames > 0:
         print(' %5d> Loaded weights from file' % (pid,))


### PR DESCRIPTION
added python 2.x compatibility
added workaround for breakout and space invaders to correct the number of moves
Note: this workaround just tells the acting methods that the move space will be 4 instead of the default 6. So, the network will be making a prediction amongst  0,1,2,3 which corresponds to ['NOOP', 'FIRE', 'RIGHT', 'LEFT'] - thus, we ignore the RIGHTFIRE and LEFTFIRE which are not needed for breakout.